### PR TITLE
Support for win32 releases. Ref #160

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,19 @@ jobs:
   include:
   - dist: xenial
     os: linux
+    env: ARCH="x64"
   - dist: trusty 
     os: linux
+    env: ARCH="x64"
   - dist: bionic
     os: linux
+    env: ARCH="x64"
   - os: osx
+    env: ARCH="x64"
   - os: windows
+    env: ARCH="x64"
+  - os: windows
+    env: ARCH="x86"
 language: c
 compiler: gcc
 os: linux
@@ -63,14 +70,20 @@ before_install:
     else
       export FILE_TAIL="tgz";
     fi
-  - export FILE_NAME=$FILE_ROOT-$TRAVIS_OS_NAME-$TRAVIS_BRANCH.$FILE_TAIL
+  - export FILE_NAME=$FILE_ROOT-$TRAVIS_OS_NAME-$ARCH-$TRAVIS_BRANCH.$FILE_TAIL
 
   # Make binaries for the library as appropriate
-  - if [[ $BUILD == "True" && $TRAVIS_OS_NAME == "windows" ]]; then
+  - if [[ $BUILD == "True" && $TRAVIS_OS_NAME == "windows" && $ARCH == "x64" ]]; then
       cd cmake && cmake -G "Visual Studio 15 2017 Win64" .. ;
       export MSBUILD_PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/";
       export PATH=$MSBUILD_PATH:$PATH;
       MSBuild.exe INSTALL.vcxproj //m //nologo //verbosity:normal //p:Configuration=Release //p:Platform=x64;
+      cd ..;
+    elif [[ $BUILD == "True" && $TRAVIS_OS_NAME == "windows" && $ARCH == "x86" ]]; then
+      cd cmake && cmake "Visual Studio 16 2019" -A Win32 .. ;
+      export MSBUILD_PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin/";
+      export PATH=$MSBUILD_PATH:$PATH;
+      MSBuild.exe INSTALL.vcxproj //m //nologo //verbosity:normal //p:Configuration=Release;
       cd ..;
     elif [[ $BUILD == "True" && ( $TRAVIS_OS_NAME == "linux" || $TRAVIS_OS_NAME == "osx" ) ]]; then
       cd cmake && cmake .. -DCMAKE_BUILD_TYPE=Release && make install && cd .. ;
@@ -85,7 +98,7 @@ script:
     elif [[ $BUILD == "True" && ( $TRAVIS_OS_NAME == "linux" || $TRAVIS_OS_NAME == "osx" ) ]]; then  
       tar  -zcvf $FILE_NAME -C cmake/$FILE_ROOT .;
     elif [[ $TRAVIS_OS_NAME == "windows" ]]; then
-      7z a -tzip $FILE_NAME README.md install.bat LICENSE q examples;
+      7z a -tzip $FILE_NAME README.md install.bat install32.bat LICENSE q examples;
     elif [[ $TRAVIS_OS_NAME == "linux" || $TRAVIS_OS_NAME == "osx" ]]; then
       tar  -zcvf $FILE_NAME README.md install.sh LICENSE q examples;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB SRC_FILES src/*.cpp)
 set_source_files_properties(${SRC_FILES} PROPERTIES LANGUAGE CXX)
 
 message(STATUS "Generator : ${CMAKE_GENERATOR}")
+message(STATUS "Generator Platform : ${CMAKE_GENERATOR_PLATFORM}")
 message(STATUS "Build Tool : ${CMAKE_BUILD_TOOL}")
 message(STATUS "Solace API : $ENV{BUILD_HOME}")
 
@@ -17,19 +18,30 @@ include_directories (
     $ENV{BUILD_HOME}/include
 )
 
-find_library(SOLCLIENT_LIBRARY
-    NAMES solclient libsolclient
-    HINTS "$ENV{BUILD_HOME}/lib/" "$ENV{BUILD_HOME}/lib/Win64"
-)
-
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
     set(INSTALL_SCRIPT "install.bat")
-    file(DOWNLOAD "https://github.com/KxSystems/kdb/raw/master/w64/q.lib" "${CMAKE_BINARY_DIR}/q.lib" )
+    if (CMAKE_GENERATOR_PLATFORM MATCHES "Win32")
+        file(DOWNLOAD "https://github.com/KxSystems/kdb/raw/master/w32/q.lib" "${CMAKE_BINARY_DIR}/q.lib" )
+        find_library(SOLCLIENT_LIBRARY
+            NAMES solclient libsolclient
+            HINTS "$ENV{BUILD_HOME}/lib/Win32"
+        )
+    else()
+        file(DOWNLOAD "https://github.com/KxSystems/kdb/raw/master/w64/q.lib" "${CMAKE_BINARY_DIR}/q.lib" )
+        find_library(SOLCLIENT_LIBRARY
+            NAMES solclient libsolclient
+            HINTS "$ENV{BUILD_HOME}/lib/Win64" 
+        )
+    endif()
     set(LINK_LIBS "${CMAKE_BINARY_DIR}/q.lib")
 else()
     set(INSTALL_SCRIPT "install.sh")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-strict-aliasing")
+    find_library(SOLCLIENT_LIBRARY
+        NAMES solclient libsolclient
+        HINTS "$ENV{BUILD_HOME}/lib/"
+    )
 endif()
     
 add_library (${MY_LIBRARY_NAME} SHARED ${SRC_FILES})
@@ -42,7 +54,7 @@ endif()
 target_link_libraries(${MY_LIBRARY_NAME} ${SOLCLIENT_LIBRARY} ${LINK_LIBS})
 set_target_properties(${MY_LIBRARY_NAME} PROPERTIES PREFIX "")
 
-install(FILES README.md LICENSE install.sh install.bat DESTINATION ${PROJECT_BINARY_DIR}/kdbsolace/)
+install(FILES README.md LICENSE install.sh install.bat install32.bat DESTINATION ${PROJECT_BINARY_DIR}/kdbsolace/)
 install(DIRECTORY examples DESTINATION ${PROJECT_BINARY_DIR}/kdbsolace)
 install(DIRECTORY q DESTINATION ${PROJECT_BINARY_DIR}/kdbsolace)
 install(TARGETS ${MY_LIBRARY_NAME} DESTINATION ${PROJECT_BINARY_DIR}/kdbsolace/lib OPTIONAL)

--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ Before installing, install the Solace C API if you have not yet done so:
 
 1. Download Solace C API from [here](https://solace.com/downloads/)(please select for your relevant machine type).
 2. Unzip the Solace API to a directory on the machine which the end user can read from.
-3. Add the libsolclient.dll lib directory to the kdb lib (directory e.g. C:\q\w64)
+3. Add the libsolclient.dll lib directory to the kdb lib (directory e.g. C:\q\w64 for 64-bit)
 
 To install the library and scripts, either
 
-- run the provided install.bat
+- run the provided install.bat (or install32.bat for 32-bit non-commercial version)
 
 or
 
-- copy `kdbsolace.dll` which was built or downloaded earlier, to your kdb+ install binary dir e.g. if kdb+ installed at `C:\q`, place the shared library into `C:\q\w64\`.
+- copy `kdbsolace.dll` which was built or downloaded earlier, to your kdb+ install binary dir e.g. if kdb+ installed at `C:\q`, place the shared library into `C:\q\w64\ `for 64-bit version.
 - copy the q script to load the solace API (`solace.q`) can be placed in the current working directory or within the kdb+ install directory.
 
 See examples and API documentation on how to tailor the interface for your needs.
@@ -134,7 +134,7 @@ Follow these steps for Visual Studio 15 (2017) and above:
 
   1. Download the Solace C Messaging API ( https://solace.com/downloads/ ).
   2. Set an environment variable `BUILD_HOME` to the location of the unzipped Solace C API.
-  3. Run `cmake -G "Visual Studio 15 2017 Win64"` 
+  3. Run `cmake -G "Visual Studio 15 2017 Win64"`  (or `cmake "Visual Studio 16 2019" -A Win32` if building 32-bit version)
 
 This will generate a visual studio build package. 
 

--- a/install32.bat
+++ b/install32.bat
@@ -1,0 +1,32 @@
+@echo off
+
+IF "%QHOME%"=="" (
+    ECHO ERROR: Enviroment variable QHOME is NOT defined 
+    EXIT /B
+)
+
+IF NOT EXIST %QHOME%\w32 (
+    ECHO ERROR: Installation destination %QHOME%\w32 does not exist
+    EXIT /B
+)
+
+
+IF EXIST q (
+    ECHO Copying q script to %QHOME%
+    COPY q\* %QHOME%
+    IF %ERRORLEVEL% NEQ 0 (
+        ECHO ERROR: Copy failed
+        EXIT /B %ERRORLEVEL%
+    )
+)
+
+IF EXIST lib (
+    ECHO Copying DLL to %QHOME%\w32
+    COPY lib\* %QHOME%\w32\
+    IF %ERRORLEVEL% NEQ 0 (
+        ECHO ERROR: Copy failed
+        EXIT /B %ERRORLEVEL%
+    )
+)
+
+ECHO Installation complete

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -9,8 +9,13 @@ elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
   wget -q https://products.solace.com/download/C_API_LINUX64
   tar xvf C_API_LINUX64 -C ./cbuild --strip-components=1
 elif [ "$TRAVIS_OS_NAME" == "windows" ]; then
-  wget -q https://products.solace.com/download/C_API_WIN64
-  tar xvf C_API_WIN64 -C ./cbuild --strip-components=1
+  if [ "$ARCH" == "x64" ]; then
+    wget -q https://products.solace.com/download/C_API_WIN64
+    tar xvf C_API_WIN64 -C ./cbuild --strip-components=1
+  else
+    wget -q https://products.solace.com/download/C_API_WIN32
+    tar xvf C_API_WIN32 -C ./cbuild --strip-components=1
+  fi
 else
   echo "$TRAVIS_OS_NAME is currently not supported"  
 fi


### PR DESCRIPTION
Addition of getting windows solace32 bit libs & build. Add x86/x64 to package name (useful if we eventually for non-intel apple). Separate build box on travis added for 32bit (instead of adding extra build step to existing win build box) so its easier to see if theres a build problem only with 32bit.