### PR TITLE
Ability to get different payload types. Ref: #163

### DIFF
--- a/examples/sol_sub_direct.q
+++ b/examples/sol_sub_direct.q
@@ -3,11 +3,12 @@
 \l sol_init.q
 
 -1"### Registering topic message callback";
-subUpdate:{[dest;payload;dict]
+subUpdate:{[dest;msg;dict]
  -1"### Message received";
+ payload:.solace.getPayloadAsBinary[msg];
  show(`payload`dest!("c"$payload;dest)),dict;
  }
-.solace.setTopicMsgCallback`subUpdate;
+.solace.setTopicRawMsgCallback`subUpdate;
 
 -1"### Subscribing to topic : ",string params`topic;
 .solace.subscribeTopic[params`topic;1b];

--- a/q/solace.q
+++ b/q/solace.q
@@ -12,15 +12,23 @@ sendDirect:`kdbsolace 2:(`senddirect_solace;2)
 sendDirectRequest:`kdbsolace 2:(`senddirectrequest_solace;5)
 sendPersistent:`kdbsolace 2:(`sendpersistent_solace;4)
 sendPersistentRequest:`kdbsolace 2:(`sendpersistentrequest_solace;6)
-setTopicMsgCallback:`kdbsolace 2:(`callbacktopic_solace;1)
 subscribeTopic:`kdbsolace 2:(`subscribetopic_solace;2)
 unSubscribeTopic:`kdbsolace 2:(`unsubscribetopic_solace;1)
-setQueueMsgCallback:`kdbsolace 2:(`callbackqueue_solace;1)
 bindQueue:`kdbsolace 2:(`bindqueue_solace;1)
 unBindQueue:`kdbsolace 2:(`unbindqueue_solace;1)
 sendAck:`kdbsolace 2:(`sendack_solace;2)
 endpointTopicSubscribe:`kdbsolace 2:(`endpointtopicsubscribe_solace;3)
 endpointTopicUnsubscribe:`kdbsolace 2:(`endpointtopicunsubscribe_solace;3)
 destroy:`kdbsolace 2:(`destroy_solace;1)
+
+setTopicMsgCallback:`kdbsolace 2:(`callbacktopic_solace;1)
+setQueueMsgCallback:`kdbsolace 2:(`callbackqueue_solace;1)
+
+setTopicRawMsgCallback:`kdbsolace 2:(`callbacktopicraw_solace;1)
+setQueueRawMsgCallback:`kdbsolace 2:(`callbackqueueraw_solace;1)
+
+getPayloadAsXML:`kdbsolace 2:(`getPayloadAsXML;1)
+getPayloadAsString:`kdbsolace 2:(`getPayloadAsString;1)
+getPayloadAsBinary:`kdbsolace 2:(`getPayloadAsBinary;1)
 
 \d .

--- a/src/kdbsolace.h
+++ b/src/kdbsolace.h
@@ -140,6 +140,35 @@ EXP K senddirect_solace(K topic, K data);
 EXP K callbacktopic_solace(K cb);
 
 /**
+ * See callbacktopic_solace. This function differs in that the callback function is
+ * provided with a msg pointer, rather than the payload. This msg pointer can be 
+ * pass to subsequent methods to get the payload, based on the type sent in your
+ * infrastructure (e.g. getPayloadAsString, getPayloadAsBinary, etc). This msg pointer
+ * cannot be used outside of the callback function.
+ * @param cb as per callbacktopic_solace
+ */
+EXP K callbacktopicraw_solace(K cb);
+
+/**
+ * Allows q to get the payload of the message as a string (if its of the solace string type)
+ * @param msg The msg provided to the callback function registered with callbacktopicraw_solace
+ * Returns byte array (or long representing the solace error code if the payload wasnt a string)
+ */
+EXP K getPayloadAsXML(K msg);
+/**
+ * Allows q to get the payload of the message as a string (if its of the solace string type)
+ * @param msg The msg provided to the callback function registered with callbacktopicraw_solace
+ * Returns char array (or long representing the solace error code if the payload wasnt a string)
+ */
+EXP K getPayloadAsString(K msg);
+/**
+ * Allows q to get the payload of the message as a byte array (if its of the solace binary type)
+ * @param msg The msg provided to the callback function registered with callbacktopicraw_solace
+ * Returns byte array (or long representing the solace error code if the payload wasnt a string)
+ */
+EXP K getPayloadAsBinary(K msg);
+
+/**
  * Subscribe to a topic 
  *
  * @param topic Should be a string. The Topic to subscribe to
@@ -191,6 +220,16 @@ EXP K sendpersistentrequest_solace(K destType, K dest, K data, K timeout, K repl
  * correlationid is a string. msgid is a long
  */
 EXP K callbackqueue_solace(K cb);
+
+/**
+ * See callbackqueue_solace. This function differs in that the callback function is
+ * provided with a msg pointer, rather than the payload. This msg pointer can be 
+ * pass to subsequent methods to get the payload, based on the type sent in your
+ * infrastructure (e.g. getPayloadAsString, getPayloadAsBinary, etc). This msg pointer
+ * cannot be used outside of the callback function.
+ * @param cb as per callbackqueue_solace
+ */
+EXP K callbackqueueraw_solace(K cb);
 
 /**
  * Subscribes/Binds to an endpoint (e.g. queue). The callback function provided will be called by the API whenever a message is received on the subscription


### PR DESCRIPTION
Current callbacks for new messages give the binary payload to the registered func
* setTopicMsgCallback
* setQueueMsgCallback
New alternative methods give Q the msg on their registered callback functions
* setTopicRawMsgCallback
* setQueueRawMsgCallback
when the user it given the msg, they can call one of the following to get the payload
* getPayloadAsXML
* getPayloadAsString
* getPayloadAsBinary
This isnt about us transforming the data, but how Solace encodes and stores data in the msgs - each of these calls a corresponding solace C call to get the XML/string/binary data (i.e. the solace string works when the sender has sent a solace string type message).

