### PR TITLE
travis ci/cd builds no longer supports osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ jobs:
   - dist: bionic
     os: linux
     env: ARCH="x64"
-  - os: osx
-    env: ARCH="x64"
   - os: windows
     env: ARCH="x64"
   - os: windows


### PR DESCRIPTION
message on travis site: April 1st, 2025, OSx/macOS builds will no longer be supported due to the end-of-life (EOL) of VMWare support for macOS infrastructure.