### PR TITLE
travis deploy error fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,8 @@ deploy:
   provider: releases
   token: "$GITHUB_APIKEY"
   file: "$FILE_NAME"
+  dpl_version: 1.10.16
+  skip_cleanup: true
   on:
     tags: true
     condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux) 

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,5 +107,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux) 
-  skip_cleanup: 'true' #  prevent Travis CI from resetting your working directory and deleting all changes made during the build 
+    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux)


### PR DESCRIPTION
was giving 

The command "ruby -S gem install dpl -v 2.0.5.4" failed and exited with 1 during . Your build has been stopped.
ERROR:  Error installing dpl:
	There are no versions of dpl (= 2.0.5.4) compatible with your Ruby & RubyGems
	dpl requires Ruby version >= 3.1. The current ruby version is 2.7.1.83.